### PR TITLE
Fix for older MacOS versions which don't support unified logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ matrix:
     # build on osx
     - os: osx
       osx_image: xcode9.1
+    - os: osx
+      osx_image: xcode8
 before_install:
     - eval "${MATRIX_EVAL}"
 script:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Header-only C++ logging library
 * Fancy name
 * Native support for various platforms (through Sinks)
   * Linux, Unix: Syslog
-  * macOS: Unified logging (os_log)
+  * macOS: Unified logging (os_log), Syslog (<10.12)
   * Android: Android Log
   * Windows: Event log, OutputDebugString
 * Several Sinks:


### PR DESCRIPTION
This should fix https://github.com/badaix/snapcast/issues/309
I've also added building against MacOS 10.11 (xcode8 - https://docs.travis-ci.com/user/reference/osx/) via TravisCI to make sure that it builds properly.
Aixlog now falls back to SysLog on MacOS < 10.12