### PR TITLE
added support for an installable cmake target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,21 @@ endif (BUILD_EXAMPLE)
 
 install(FILES include/aixlog.hpp DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
+# create interface library
+add_library(aixlog INTERFACE)
+target_include_directories(aixlog INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/>
+        $<INSTALL_INTERFACE:include>)
+
+# Make an export target
+install(TARGETS aixlog EXPORT aixlogConfig)
+
+# Install the export target as a file
+install(EXPORT aixlogConfig DESTINATION "cmake")
+
+
+
+
 FIND_PROGRAM(CLANG_FORMAT "clang-format")
 IF(CLANG_FORMAT)
 	set(CHECK_CXX_SOURCE_FILES


### PR DESCRIPTION
To leverage modern cmake features provide an installable interface target.
If deployed like this aixlog can be used with the following statements in a CMakeLists.txt file

`
find_package(aixlog)
target_link_libraries (MyTarget aixlog)
`

The required include path will be set automatically
