### PR TITLE
Allow build with cmake 4.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 # This software may be modified and distributed under the terms
 # of the MIT license.  See the LICENSE file for details.
 
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.0.0...3.10)
 
 project(aixlog VERSION 1.5.0 LANGUAGES CXX)
 set(PROJECT_DESCRIPTION "Header-only C++ logging library")


### PR DESCRIPTION
use min...max syntax to allow build with newer cmake. 

ref: https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html

fixes #18