### PR TITLE
Prevent name collisions with Windows.h macros

### DIFF
--- a/include/aixlog.hpp
+++ b/include/aixlog.hpp
@@ -51,6 +51,9 @@
 #endif
 
 #ifdef _WIN32
+// Prevent name collisions with Windows.h macros
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
 #include <Windows.h>
 // ERROR macro is defined in Windows header
 // To avoid conflict between these macro and declaration of ERROR / DEBUG in SEVERITY enum


### PR DESCRIPTION
Resolves #20 

Solves macro collisions such as min / max.
Compile speed should also be improved because significant portion of the header code is omitted when using WIN32_LEAN_AND_MEAN.

https://stackoverflow.com/questions/11040133/what-does-defining-win32-lean-and-mean-exclude-exactly
https://stackoverflow.com/questions/11544073/how-do-i-deal-with-the-max-macro-in-windows-h-colliding-with-max-in-std